### PR TITLE
Merge matomo-tracking-js into main

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -15,4 +15,22 @@
 
     {{ $js := resources.Get "javascript/utils.js" | resources.Minify | resources.Fingerprint "sha512" }}
     <script src="{{ $js.Permalink }}" defer></script>
+
+    {{ if eq hugo.Environment "production" }}
+    <!-- Matomo -->
+    <script>
+      var _paq = window._paq = window._paq || [];
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+        var u="https://stats.rrchnm.org/";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        _paq.push(['setSiteId', '106']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+      })();
+    </script>
+    <!-- End Matomo Code -->
+    {{ end }}
 </head>


### PR DESCRIPTION
Adds Matomo tracking JS code before end of head tag.
Should only be generated on production builds.